### PR TITLE
Updated get-diff-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check if Dockerfile or Conda environment changed
-        uses: technote-space/get-diff-action@v3
+        uses: technote-space/get-diff-action@v4
         with:
           PREFIX_FILTER: |
             Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check if Dockerfile or Conda environment changed
-        uses: technote-space/get-diff-action@v1
+        uses: technote-space/get-diff-action@v3
         with:
           PREFIX_FILTER: |
             Dockerfile


### PR DESCRIPTION
We have been using get-diff-action@v1, setting it to det-diff-action@v4

The newest version should have the set-env issue fixed