### PR TITLE
Use FILES instead of PREFIX_FILTER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check if Dockerfile or Conda environment changed
         uses: technote-space/get-diff-action@v4
         with:
-          PREFIX_FILTER: |
+          FILES: |
             Dockerfile
             environment.yml
 


### PR DESCRIPTION
PREFIX_FILTER is apparently not supported anymore in the new veresion of get-diff-action
FILES is supported and should do the trick (as we specified Dockerfile and environment.yml) anyway.

@ggabernet 