### PR TITLE
adapt pipeline to nf-schema 2.1.0

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/nf-core/testpipeline/master/assets/schema_input.json",
     "title": "nf-core/testpipeline pipeline - params.input schema",
     "description": "Schema for the file provided with params.input",

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,8 +31,8 @@ params {
     plaintext_email            = false
     monochrome_logs            = false
     hook_url                   = null
-    help                       = false
     version                    = false
+    validate_params            = false
 
     // Config options
     config_profile_name        = null
@@ -48,12 +48,10 @@ params {
     max_cpus                   = 16
     max_time                   = '240.h'
 
-    // Schema validation default options
-    validationFailUnrecognisedParams = false
-    validationLenientMode            = false
-    validationSchemaIgnoreParams     = 'genomes,igenomes_base'
-    validationShowHiddenParams       = false
-    validate_params                  = true
+    // Help options
+    help                       = false
+    helpFull                   = false
+    showHidden                 = false
 
 }
 
@@ -180,7 +178,7 @@ singularity.registry = 'quay.io'
 
 // Nextflow plugins
 plugins {
-    id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.1.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 // Load igenomes.config if required
@@ -233,6 +231,108 @@ manifest {
     nextflowVersion = '!>=23.04.0'
     version         = '1.0dev'
     doi             = ''
+}
+
+validation {
+    monochromeLogs = false
+    // Use --help, --help <parameter> or --helpFull to show a help message
+    help {
+        enabled = true
+        beforeText = nfCoreLogo()
+        command = "nextflow run ${manifest.name} -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
+        afterText = workflowCitations()
+    }
+}
+
+def workflowCitations() {
+    return "If you use ${manifest.name} for your analysis please cite:\n\n" +
+    "* The pipeline\n" +
+    "  ${manifest.doi}\n\n" +
+    "* The nf-core framework\n" +
+    "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
+    "* Software dependencies\n" +
+    "  https://github.com/${manifest.name}/blob/master/CITATIONS.md"
+}
+
+def nfCoreLogo() {
+    def Map colors = logColours(validation.monochromeLogs)
+    return String.format(
+        """\n
+        -${colors.dim}----------------------------------------------------${colors.reset}-
+                                                ${colors.green},--.${colors.black}/${colors.green},-.${colors.reset}
+        ${colors.blue}        ___     __   __   __   ___     ${colors.green}/,-._.--~\'${colors.reset}
+        ${colors.blue}  |\\ | |__  __ /  ` /  \\ |__) |__         ${colors.yellow}}  {${colors.reset}
+        ${colors.blue}  | \\| |       \\__, \\__/ |  \\ |___     ${colors.green}\\`-._,-`-,${colors.reset}
+                                                ${colors.green}`._,._,\'${colors.reset}
+        ${colors.purple}  ${manifest.name} ${manifest.version}${colors.reset}
+        -${colors.dim}----------------------------------------------------${colors.reset}-
+        """.stripIndent()
+    )
+}
+
+def logColours(monochrome_logs=true) {
+    Map colorcodes = [:]
+
+    // Reset / Meta
+    colorcodes['reset']      = monochrome_logs ? '' : "\033[0m"
+    colorcodes['bold']       = monochrome_logs ? '' : "\033[1m"
+    colorcodes['dim']        = monochrome_logs ? '' : "\033[2m"
+    colorcodes['underlined'] = monochrome_logs ? '' : "\033[4m"
+    colorcodes['blink']      = monochrome_logs ? '' : "\033[5m"
+    colorcodes['reverse']    = monochrome_logs ? '' : "\033[7m"
+    colorcodes['hidden']     = monochrome_logs ? '' : "\033[8m"
+
+    // Regular Colors
+    colorcodes['black']      = monochrome_logs ? '' : "\033[0;30m"
+    colorcodes['red']        = monochrome_logs ? '' : "\033[0;31m"
+    colorcodes['green']      = monochrome_logs ? '' : "\033[0;32m"
+    colorcodes['yellow']     = monochrome_logs ? '' : "\033[0;33m"
+    colorcodes['blue']       = monochrome_logs ? '' : "\033[0;34m"
+    colorcodes['purple']     = monochrome_logs ? '' : "\033[0;35m"
+    colorcodes['cyan']       = monochrome_logs ? '' : "\033[0;36m"
+    colorcodes['white']      = monochrome_logs ? '' : "\033[0;37m"
+
+    // Bold
+    colorcodes['bblack']     = monochrome_logs ? '' : "\033[1;30m"
+    colorcodes['bred']       = monochrome_logs ? '' : "\033[1;31m"
+    colorcodes['bgreen']     = monochrome_logs ? '' : "\033[1;32m"
+    colorcodes['byellow']    = monochrome_logs ? '' : "\033[1;33m"
+    colorcodes['bblue']      = monochrome_logs ? '' : "\033[1;34m"
+    colorcodes['bpurple']    = monochrome_logs ? '' : "\033[1;35m"
+    colorcodes['bcyan']      = monochrome_logs ? '' : "\033[1;36m"
+    colorcodes['bwhite']     = monochrome_logs ? '' : "\033[1;37m"
+
+    // Underline
+    colorcodes['ublack']     = monochrome_logs ? '' : "\033[4;30m"
+    colorcodes['ured']       = monochrome_logs ? '' : "\033[4;31m"
+    colorcodes['ugreen']     = monochrome_logs ? '' : "\033[4;32m"
+    colorcodes['uyellow']    = monochrome_logs ? '' : "\033[4;33m"
+    colorcodes['ublue']      = monochrome_logs ? '' : "\033[4;34m"
+    colorcodes['upurple']    = monochrome_logs ? '' : "\033[4;35m"
+    colorcodes['ucyan']      = monochrome_logs ? '' : "\033[4;36m"
+    colorcodes['uwhite']     = monochrome_logs ? '' : "\033[4;37m"
+
+    // High Intensity
+    colorcodes['iblack']     = monochrome_logs ? '' : "\033[0;90m"
+    colorcodes['ired']       = monochrome_logs ? '' : "\033[0;91m"
+    colorcodes['igreen']     = monochrome_logs ? '' : "\033[0;92m"
+    colorcodes['iyellow']    = monochrome_logs ? '' : "\033[0;93m"
+    colorcodes['iblue']      = monochrome_logs ? '' : "\033[0;94m"
+    colorcodes['ipurple']    = monochrome_logs ? '' : "\033[0;95m"
+    colorcodes['icyan']      = monochrome_logs ? '' : "\033[0;96m"
+    colorcodes['iwhite']     = monochrome_logs ? '' : "\033[0;97m"
+
+    // Bold High Intensity
+    colorcodes['biblack']    = monochrome_logs ? '' : "\033[1;90m"
+    colorcodes['bired']      = monochrome_logs ? '' : "\033[1;91m"
+    colorcodes['bigreen']    = monochrome_logs ? '' : "\033[1;92m"
+    colorcodes['biyellow']   = monochrome_logs ? '' : "\033[1;93m"
+    colorcodes['biblue']     = monochrome_logs ? '' : "\033[1;94m"
+    colorcodes['bipurple']   = monochrome_logs ? '' : "\033[1;95m"
+    colorcodes['bicyan']     = monochrome_logs ? '' : "\033[1;96m"
+    colorcodes['biwhite']    = monochrome_logs ? '' : "\033[1;97m"
+
+    return colorcodes
 }
 
 // Load modules.config for DSL2 module specific options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/nf-core/testpipeline/master/nextflow_schema.json",
     "title": "nf-core/testpipeline pipeline parameters",
     "description": "An example pipeline used to test new nf-core infrastructure and common code.",
     "type": "object",
-    "definitions": {
+    "$defs": {
         "input_output_options": {
             "title": "Input/output options",
             "type": "object",
@@ -278,19 +278,19 @@
     },
     "allOf": [
         {
-            "$ref": "#/definitions/input_output_options"
+            "$ref": "#/$defs/input_output_options"
         },
         {
-            "$ref": "#/definitions/reference_genome_options"
+            "$ref": "#/$defs/reference_genome_options"
         },
         {
-            "$ref": "#/definitions/institutional_config_options"
+            "$ref": "#/$defs/institutional_config_options"
         },
         {
-            "$ref": "#/definitions/max_job_request_options"
+            "$ref": "#/$defs/max_job_request_options"
         },
         {
-            "$ref": "#/definitions/generic_options"
+            "$ref": "#/$defs/generic_options"
         }
     ]
 }

--- a/null/pipeline_info/execution_trace_2024-08-13_15-33-42.txt
+++ b/null/pipeline_info/execution_trace_2024-08-13_15-33-42.txt
@@ -1,0 +1,1 @@
+task_id	hash	native_id	name	status	exit	submit	duration	realtime	%cpu	peak_rss	peak_vmem	rchar	wchar

--- a/subworkflows/local/utils_nfcore_testpipeline_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_testpipeline_pipeline/main.nf
@@ -9,8 +9,8 @@
 */
 
 include { UTILS_NFVALIDATION_PLUGIN } from '../../nf-core/utils_nfvalidation_plugin'
-include { paramsSummaryMap          } from 'plugin/nf-validation'
-include { fromSamplesheet           } from 'plugin/nf-validation'
+include { paramsSummaryMap          } from 'plugin/nf-schema'
+include { samplesheetToList         } from 'plugin/nf-schema'
 include { UTILS_NEXTFLOW_PIPELINE   } from '../../nf-core/utils_nextflow_pipeline'
 include { completionEmail           } from '../../nf-core/utils_nfcore_pipeline'
 include { completionSummary         } from '../../nf-core/utils_nfcore_pipeline'
@@ -54,14 +54,7 @@ workflow PIPELINE_INITIALISATION {
     //
     // Validate parameters and generate parameter summary to stdout
     //
-    pre_help_text = nfCoreLogo(monochrome_logs)
-    post_help_text = '\n' + workflowCitation() + '\n' + dashedLine(monochrome_logs)
-    def String workflow_command = "nextflow run ${workflow.manifest.name} -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
     UTILS_NFVALIDATION_PLUGIN (
-        help,
-        workflow_command,
-        pre_help_text,
-        post_help_text,
         validate_params,
         "nextflow_schema.json"
     )
@@ -80,8 +73,7 @@ workflow PIPELINE_INITIALISATION {
     //
     // Create channel from input file provided through params.input
     //
-    Channel
-        .fromSamplesheet("input")
+    Channel.fromList(samplesheetToList(params.input, "assets/schema_input.json"))
         .map {
             meta, fastq_1, fastq_2 ->
                 if (!fastq_2) {

--- a/subworkflows/nf-core/utils_nfvalidation_plugin/main.nf
+++ b/subworkflows/nf-core/utils_nfvalidation_plugin/main.nf
@@ -8,9 +8,9 @@
 ========================================================================================
 */
 
-include { paramsHelp         } from 'plugin/nf-validation'
-include { paramsSummaryLog   } from 'plugin/nf-validation'
-include { validateParameters } from 'plugin/nf-validation'
+// include { paramsHelp         } from 'plugin/nf-schema'
+include { paramsSummaryLog   } from 'plugin/nf-schema'
+include { validateParameters } from 'plugin/nf-schema'
 
 /*
 ========================================================================================
@@ -21,10 +21,6 @@ include { validateParameters } from 'plugin/nf-validation'
 workflow UTILS_NFVALIDATION_PLUGIN {
 
     take:
-    print_help       // boolean: print help
-    workflow_command //  string: default commmand used to run pipeline
-    pre_help_text    //  string: string to be printed before help text and summary log
-    post_help_text   //  string: string to be printed after help text and summary log
     validate_params  // boolean: validate parameters
     schema_filename  //    path: JSON schema file, null to use default value
 
@@ -32,23 +28,10 @@ workflow UTILS_NFVALIDATION_PLUGIN {
 
     log.debug "Using schema file: ${schema_filename}"
 
-    // Default values for strings
-    pre_help_text    = pre_help_text    ?: ''
-    post_help_text   = post_help_text   ?: ''
-    workflow_command = workflow_command ?: ''
-
-    //
-    // Print help message if needed
-    //
-    if (print_help) {
-        log.info pre_help_text + paramsHelp(workflow_command, parameters_schema: schema_filename) + post_help_text
-        System.exit(0)
-    }
-
     //
     // Print parameter summary to stdout
     //
-    log.info pre_help_text + paramsSummaryLog(workflow, parameters_schema: schema_filename) + post_help_text
+    log.info paramsSummaryLog(workflow, parameters_schema: schema_filename)
 
     //
     // Validate parameters relative to the parameter JSON schema


### PR DESCRIPTION
This PR shows an implementation of nf-schema 2.1.0 on the test pipeline. (Tests will fail because `2.1.0` has not been released yet).

Running `nextflow run main.nf --help` shows this:
```
$ nextflow run main.nf --help
Nextflow 24.04.4 is available - Please consider updating your version to it

 N E X T F L O W   ~  version 24.04.3

Launching `main.nf` [hopeful_meninsky] DSL2 - revision: d17b498066



------------------------------------------------------
                                        ,--./,-.
        ___     __   __   __   ___     /,-._.--~'
  |\ | |__  __ /  ` /  \ |__) |__         }  {
  | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                        `._,._,'
  nf-core/testpipeline 1.0dev
------------------------------------------------------
Typical pipeline command:

  nextflow run nf-core/testpipeline -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>

--help                          [boolean, string] Show the help message for all top level parameters. When a parameter is given to `--help`, the full help message of that parameter will be printed. 
--helpFull                      [boolean]         Show the help message for all non-hidden parameters. 
--showHidden                    [boolean]         Show all hidden parameters in the help message. This needs to be used in combination with `--help` or `--helpFull`. 

Input/output options
  --input                       [string] Path to comma-separated file containing information about the samples in the experiment. 
  --outdir                      [string] The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure. 
  --email                       [string] Email address for completion summary. 
  --multiqc_title               [string] MultiQC report title. Printed as page header, used for filename if not otherwise specified. 

Reference genome options
  --genome                      [string] Name of iGenomes reference. 
  --fasta                       [string] Path to FASTA genome file. 

Generic options
  --multiqc_methods_description [string] Custom MultiQC yaml file containing HTML including a methods description. 

 !! Hiding 24 param(s), use the `--showHidden` parameter to show them !!
------------------------------------------------------
If you use nf-core/testpipeline for your analysis please cite:

* The pipeline
  

* The nf-core framework
  https://doi.org/10.1038/s41587-020-0439-x

* Software dependencies
  https://github.com/nf-core/testpipeline/blob/master/CITATIONS.md
```